### PR TITLE
pkg/dom refactoring

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -140,6 +140,7 @@ type Window interface {
 
 	// Methods
 	Write(io.Writer, Node) (int, error)
+	WriteIndented(io.Writer, Node, string) (int, error)
 	//Read(io.Reader, string) (Document, error)
 }
 

--- a/pkg/dom/attr.go
+++ b/pkg/dom/attr.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"io"
 	"strconv"
+	"strings"
 
 	dom "github.com/djthorpe/go-wasmbuild"
 )
@@ -22,31 +23,17 @@ type attr struct {
 // STRINGIFY
 
 func (this *attr) String() string {
-	str := "<DOMAttribute"
+	var b strings.Builder
+	b.WriteString("<DOMAttribute")
 	if name := this.Name(); name != "" {
-		str += fmt.Sprintf(" %v=%q", name, this.Value())
+		fmt.Fprintf(&b, " %v=%q", name, this.Value())
 	}
-	return str + ">"
+	b.WriteString(">")
+	return b.String()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // PROPERTIES
-
-func (this *attr) NextSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).nextChild(this)
-	}
-}
-
-func (this *attr) PreviousSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).previousChild(this)
-	}
-}
 
 func (this *attr) Name() string {
 	return this.name
@@ -67,25 +54,23 @@ func (this *attr) OwnerElement() dom.Element {
 /////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 
-func (this *attr) AppendChild(child dom.Node) dom.Node {
-	return nil
-}
-
 func (this *attr) CloneNode(bool) dom.Node {
 	return NewNode(this.document, this.name, this.nodetype, this.cdata)
 }
 
+// Child manipulation methods are no-ops for attribute nodes (leaf nodes)
+func (this *attr) AppendChild(child dom.Node) dom.Node {
+	return nil
+}
+
 func (this *attr) InsertBefore(new dom.Node, ref dom.Node) dom.Node {
-	// NO-OP
 	return nil
 }
 
 func (this *attr) RemoveChild(child dom.Node) {
-	// NO-OP
 }
 
 func (this *attr) ReplaceChild(dom.Node, dom.Node) {
-	// NO-OP
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/comment.go
+++ b/pkg/dom/comment.go
@@ -96,3 +96,40 @@ func (this *comment) write(w io.Writer) (int, error) {
 	}
 	return s, nil
 }
+
+func (this *comment) writeIndented(w io.Writer, level int, indent string) (int, error) {
+	s := 0
+	indentStr := strings.Repeat(indent, level)
+
+	if n, err := w.Write([]byte(indentStr)); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
+	if n, err := w.Write(startcomment); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
+	if n, err := w.Write([]byte(html.EscapeString(this.cdata))); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
+	if n, err := w.Write(endcomment); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
+	if n, err := w.Write([]byte("\n")); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
+	return s, nil
+}

--- a/pkg/dom/comment.go
+++ b/pkg/dom/comment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"strings"
 
 	dom "github.com/djthorpe/go-wasmbuild"
 )
@@ -29,29 +30,15 @@ var (
 // STRINGIFY
 
 func (this *comment) String() string {
-	str := "<DOMComment"
-	str += fmt.Sprintf(" data=%q length=%v", this.Data(), this.Length())
-	return str + ">"
+	var b strings.Builder
+	b.WriteString("<DOMComment")
+	fmt.Fprintf(&b, " data=%q length=%v", this.Data(), this.Length())
+	b.WriteString(">")
+	return b.String()
 }
 
 /////////////////////////////////////////////////////////////////////
 // PROPERTIES
-
-func (this *comment) NextSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).nextChild(this)
-	}
-}
-
-func (this *comment) PreviousSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).previousChild(this)
-	}
-}
 
 func (this *comment) Data() string {
 	return this.cdata
@@ -64,26 +51,23 @@ func (this *comment) Length() int {
 /////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 
-func (this *comment) AppendChild(child dom.Node) dom.Node {
-	// NO-OP
-	return nil
-}
-
 func (this *comment) CloneNode(bool) dom.Node {
 	return NewNode(this.document, this.name, this.nodetype, this.cdata)
 }
 
+// Child manipulation methods are no-ops for comment nodes (leaf nodes)
+func (this *comment) AppendChild(child dom.Node) dom.Node {
+	return nil
+}
+
 func (this *comment) InsertBefore(new dom.Node, ref dom.Node) dom.Node {
-	// NO-OP
 	return nil
 }
 
 func (this *comment) RemoveChild(child dom.Node) {
-	// NO-OP
 }
 
 func (this *comment) ReplaceChild(dom.Node, dom.Node) {
-	// NO-OP
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/doctype.go
+++ b/pkg/dom/doctype.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	dom "github.com/djthorpe/go-wasmbuild"
 )
@@ -31,17 +32,19 @@ var (
 // STRINGIFY
 
 func (this *doctype) String() string {
-	str := "<DOMDocumentType"
+	var b strings.Builder
+	b.WriteString("<DOMDocumentType")
 	if name := this.Name(); name != "" {
-		str += fmt.Sprintf(" name=%q", name)
+		fmt.Fprintf(&b, " name=%q", name)
 	}
 	if publicid := this.PublicId(); publicid != "" {
-		str += fmt.Sprintf(" publicId=%q", publicid)
+		fmt.Fprintf(&b, " publicId=%q", publicid)
 	}
 	if systemid := this.SystemId(); systemid != "" {
-		str += fmt.Sprintf(" systemId=%q", systemid)
+		fmt.Fprintf(&b, " systemId=%q", systemid)
 	}
-	return str + ">"
+	b.WriteString(">")
+	return b.String()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -71,11 +74,6 @@ func (this *doctype) SystemId() string {
 /////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 
-func (this *doctype) AppendChild(child dom.Node) dom.Node {
-	// NO-OP
-	return nil
-}
-
 func (this *doctype) CloneNode(bool) dom.Node {
 	clone := NewNode(this.document, this.name, this.nodetype, this.cdata).(*doctype)
 	clone.publicid = this.publicid
@@ -83,17 +81,19 @@ func (this *doctype) CloneNode(bool) dom.Node {
 	return clone
 }
 
+// Child manipulation methods are no-ops for doctype nodes (leaf nodes)
+func (this *doctype) AppendChild(child dom.Node) dom.Node {
+	return nil
+}
+
 func (this *doctype) InsertBefore(new dom.Node, ref dom.Node) dom.Node {
-	// NO-OP
 	return nil
 }
 
 func (this *doctype) RemoveChild(child dom.Node) {
-	// NO-OP
 }
 
 func (this *doctype) ReplaceChild(dom.Node, dom.Node) {
-	// NO-OP
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/document.go
+++ b/pkg/dom/document.go
@@ -4,6 +4,7 @@ package dom
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	// Packages
@@ -146,6 +147,66 @@ func (this *document) ActiveElement() dom.Element {
 
 func (this *document) v() *node {
 	return this.node
+}
+
+func (this *document) write(w io.Writer) (int, error) {
+	s := 0
+
+	// Write doctype if present
+	if this.doctype != nil {
+		if n, err := writeNode(w, this.doctype); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+		// Add newline after doctype
+		if n, err := w.Write([]byte("\n")); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+	}
+
+	// Write root element (usually <html>)
+	if root := this.FirstChild(); root != nil {
+		if n, err := writeNode(w, root); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+	}
+
+	return s, nil
+}
+
+func (this *document) writeIndented(w io.Writer, level int, indent string) (int, error) {
+	s := 0
+
+	// Write doctype if present (no indentation)
+	if this.doctype != nil {
+		if n, err := writeNode(w, this.doctype); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+		// Add newline after doctype
+		if n, err := w.Write([]byte("\n")); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+	}
+
+	// Write root element with indentation
+	if root := this.FirstChild(); root != nil {
+		if n, err := writeNodeIndented(w, root, level, indent); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+	}
+
+	return s, nil
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/document.go
+++ b/pkg/dom/document.go
@@ -1,9 +1,10 @@
-//go:build !wasm
+//go:build !js
 
 package dom
 
 import (
 	"fmt"
+	"strings"
 
 	// Packages
 	dom "github.com/djthorpe/go-wasmbuild"
@@ -75,7 +76,13 @@ func (doc *document) Title() string {
 	if doc.head == nil {
 		return ""
 	}
-	return fmt.Sprint(doc.node.v())
+	// Find the title element in the head
+	for child := doc.head.FirstChild(); child != nil; child = child.NextSibling() {
+		if child.NodeType() == dom.ELEMENT_NODE && child.NodeName() == "title" {
+			return child.TextContent()
+		}
+	}
+	return ""
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -145,7 +152,9 @@ func (this *document) v() *node {
 // STRINGIFY
 
 func (this *document) String() string {
-	str := "<DOMDocument"
-	str += fmt.Sprint(" ", this.node)
-	return str + ">"
+	var b strings.Builder
+	b.WriteString("<DOMDocument")
+	fmt.Fprint(&b, " ", this.node)
+	b.WriteString(">")
+	return b.String()
 }

--- a/pkg/dom/document_wasm.go
+++ b/pkg/dom/document_wasm.go
@@ -1,4 +1,4 @@
-//go:build wasm
+//go:build js
 
 package dom
 

--- a/pkg/dom/element.go
+++ b/pkg/dom/element.go
@@ -1,4 +1,4 @@
-//go:build !wasm
+//go:build !js
 
 package dom
 
@@ -27,29 +27,15 @@ var _ dom.Element = (*element)(nil)
 // STRINGIFY
 
 func (this *element) String() string {
-	str := "<DOMElement"
-	str += fmt.Sprint(" ", this.node)
-	return str + ">"
+	var b strings.Builder
+	b.WriteString("<DOMElement")
+	fmt.Fprint(&b, " ", this.node)
+	b.WriteString(">")
+	return b.String()
 }
 
 /////////////////////////////////////////////////////////////////////
 // PROPERTIES
-
-func (this *element) NextSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).nextChild(this)
-	}
-}
-
-func (this *element) PreviousSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).previousChild(this)
-	}
-}
 
 func (this *element) InnerHTML() string {
 	buf := new(bytes.Buffer)

--- a/pkg/dom/element.go
+++ b/pkg/dom/element.go
@@ -40,7 +40,7 @@ func (this *element) String() string {
 func (this *element) InnerHTML() string {
 	buf := new(bytes.Buffer)
 	for child := this.FirstChild(); child != nil; child = child.NextSibling() {
-		child.(nodevalue).write(buf)
+		writeNode(buf, child)
 	}
 	return buf.String()
 }
@@ -79,7 +79,7 @@ func (this *element) Style() dom.Style {
 func (this *element) SetAttribute(name, value string) dom.Attr {
 	attr := this.document.CreateAttribute(name)
 	attr.SetValue(value)
-	attr.(nodevalue).v().parent = this
+	getNode(attr).parent = this
 	this.attrs[name] = attr
 	return attr
 }
@@ -157,7 +157,7 @@ func (this *element) write(w io.Writer) (int, error) {
 
 	// Write children
 	for _, child := range this.node.children {
-		if n, err := child.(nodevalue).write(w); err != nil {
+		if n, err := writeNode(w, child); err != nil {
 			return 0, err
 		} else {
 			s += n

--- a/pkg/dom/node.go
+++ b/pkg/dom/node.go
@@ -329,6 +329,10 @@ func findNextChild(parent *node, child dom.Node) dom.Node {
 		return nil
 	}
 	for i, c := range parent.children {
+		// Note: We use c.Equals(child) instead of c != child to properly compare
+		// the underlying *node pointers. Equals() is safe here - it only calls
+		// getNode() (a pure type switch) and does pointer comparison with ==.
+		// No recursion occurs.
 		if !c.Equals(child) {
 			continue
 		}
@@ -348,6 +352,10 @@ func findPreviousChild(parent *node, child dom.Node) dom.Node {
 		return nil
 	}
 	for i, c := range parent.children {
+		// Note: We use c.Equals(child) instead of c != child to properly compare
+		// the underlying *node pointers. Equals() is safe here - it only calls
+		// getNode() (a pure type switch) and does pointer comparison with ==.
+		// No recursion occurs.
 		if !c.Equals(child) {
 			continue
 		}

--- a/pkg/dom/node.go
+++ b/pkg/dom/node.go
@@ -301,6 +301,27 @@ func writeNode(w io.Writer, n dom.Node) (int, error) {
 	}
 }
 
+// writeNodeIndented serializes any node type to HTML with indentation
+// level is the current indent level, indent is the string to use (e.g., "  " or "\t")
+func writeNodeIndented(w io.Writer, n dom.Node, level int, indent string) (int, error) {
+	switch v := n.(type) {
+	case *element:
+		return v.writeIndented(w, level, indent)
+	case *text:
+		return v.write(w) // Text nodes don't get indented
+	case *comment:
+		return v.writeIndented(w, level, indent)
+	case *doctype:
+		return v.write(w) // Doctype doesn't get indented
+	case *document:
+		return v.writeIndented(w, level, indent)
+	case *node:
+		return v.writeIndented(w, level, indent)
+	default:
+		return writeNode(w, n) // Fallback to non-indented
+	}
+}
+
 // findNextChild finds the next sibling of child in parent's children
 // This replaces the nodevalue interface nextChild() method
 func findNextChild(parent *node, child dom.Node) dom.Node {
@@ -358,5 +379,32 @@ func (this *node) write(w io.Writer) (int, error) {
 	} else {
 		s += n
 	}
+	return s, nil
+}
+
+func (this *node) writeIndented(w io.Writer, level int, indent string) (int, error) {
+	s := 0
+	indentStr := strings.Repeat(indent, level)
+
+	if n, err := w.Write([]byte(indentStr + "<" + this.name + ">\n")); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
+	for _, child := range this.children {
+		if n, err := writeNodeIndented(w, child, level+1, indent); err != nil {
+			return 0, err
+		} else {
+			s += n
+		}
+	}
+
+	if n, err := w.Write([]byte(indentStr + "</" + this.name + ">\n")); err != nil {
+		return 0, err
+	} else {
+		s += n
+	}
+
 	return s, nil
 }

--- a/pkg/dom/node_wasm.go
+++ b/pkg/dom/node_wasm.go
@@ -17,6 +17,9 @@ type node struct {
 	js.Value
 }
 
+// nodevalue is an internal interface for JS builds that extends dom.Node
+// with a method to access the underlying js.Value for JavaScript interop.
+// This interface is different from the non-JS build's nodevalue interface.
 type nodevalue interface {
 	dom.Node
 	v() js.Value

--- a/pkg/dom/node_wasm.go
+++ b/pkg/dom/node_wasm.go
@@ -17,12 +17,35 @@ type node struct {
 	js.Value
 }
 
-// nodevalue is an internal interface for JS builds that extends dom.Node
-// with a method to access the underlying js.Value for JavaScript interop.
-// This interface is different from the non-JS build's nodevalue interface.
-type nodevalue interface {
-	dom.Node
-	v() js.Value
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE HELPERS
+
+// toJSValue returns the underlying js.Value from any node type
+// This replaces the nodevalue interface v() method
+func toJSValue(n dom.Node) js.Value {
+	if n == nil {
+		return js.Undefined()
+	}
+	// All node types embed *node which embeds js.Value
+	// So we can use a type assertion to access it
+	switch v := n.(type) {
+	case *node:
+		return v.Value
+	case *element:
+		return v.node.Value
+	case *attr:
+		return v.node.Value
+	case *text:
+		return v.node.Value
+	case *comment:
+		return v.node.Value
+	case *doctype:
+		return v.node.Value
+	case *document:
+		return v.node.Value
+	default:
+		panic("toJSValue: unknown node type")
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -125,7 +148,7 @@ func (this *node) ChildNodes() []dom.Node {
 }
 
 func (this *node) Contains(other dom.Node) bool {
-	return this.Call("contains", other.(nodevalue).v()).Bool()
+	return this.Call("contains", toJSValue(other)).Bool()
 }
 
 func (this *node) FirstChild() dom.Node {
@@ -180,11 +203,11 @@ func (this *node) TextContent() string {
 // PUBLIC METHODS
 
 func (this *node) Equals(other dom.Node) bool {
-	return this.Equal(other.(nodevalue).v())
+	return this.Equal(toJSValue(other))
 }
 
 func (this *node) AppendChild(child dom.Node) dom.Node {
-	this.Call("appendChild", child.(nodevalue).v())
+	this.Call("appendChild", toJSValue(child))
 	return child
 }
 
@@ -196,17 +219,17 @@ func (this *node) InsertBefore(child dom.Node, before dom.Node) dom.Node {
 	if before == nil {
 		return this.AppendChild(child)
 	} else {
-		this.Call("insertBefore", child.(nodevalue).v(), before.(nodevalue).v())
+		this.Call("insertBefore", toJSValue(child), toJSValue(before))
 		return child
 	}
 }
 
 func (this *node) RemoveChild(child dom.Node) {
-	this.Call("removeChild", child.(nodevalue).v())
+	this.Call("removeChild", toJSValue(child))
 }
 
 func (this *node) ReplaceChild(new, old dom.Node) {
-	this.Call("replaceChild", new.(nodevalue).v(), old.(nodevalue).v())
+	this.Call("replaceChild", toJSValue(new), toJSValue(old))
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/text.go
+++ b/pkg/dom/text.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"strings"
 
 	dom "github.com/djthorpe/go-wasmbuild"
 )
@@ -21,29 +22,15 @@ type text struct {
 // STRINGIFY
 
 func (this *text) String() string {
-	str := "<DOMText"
-	str += fmt.Sprintf(" data=%q length=%v", this.Data(), this.Length())
-	return str + ">"
+	var b strings.Builder
+	b.WriteString("<DOMText")
+	fmt.Fprintf(&b, " data=%q length=%v", this.Data(), this.Length())
+	b.WriteString(">")
+	return b.String()
 }
 
 /////////////////////////////////////////////////////////////////////
 // PROPERTIES
-
-func (this *text) NextSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).nextChild(this)
-	}
-}
-
-func (this *text) PreviousSibling() dom.Node {
-	if this.parent == nil {
-		return nil
-	} else {
-		return this.parent.(nodevalue).previousChild(this)
-	}
-}
 
 func (this *text) Data() string {
 	return this.cdata
@@ -60,22 +47,19 @@ func (this *text) CloneNode(bool) dom.Node {
 	return NewNode(this.document, this.name, this.nodetype, this.cdata)
 }
 
+// Child manipulation methods are no-ops for text nodes (leaf nodes)
 func (this *text) AppendChild(child dom.Node) dom.Node {
-	// NO-OP
 	return nil
 }
 
 func (this *text) InsertBefore(new dom.Node, ref dom.Node) dom.Node {
-	// NO-OP
 	return nil
 }
 
 func (this *text) RemoveChild(child dom.Node) {
-	// NO-OP
 }
 
 func (this *text) ReplaceChild(dom.Node, dom.Node) {
-	// NO-OP
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/tokenlist.go
+++ b/pkg/dom/tokenlist.go
@@ -1,4 +1,4 @@
-//go:build !wasm
+//go:build !js
 
 package dom
 
@@ -118,10 +118,12 @@ func (tokenlist *tokenlist) Toggle(value string, force ...bool) bool {
 // STRINGIFY
 
 func (tokenlist *tokenlist) String() string {
-	str := "<DOMTokenList"
+	var b strings.Builder
+	b.WriteString("<DOMTokenList")
 	values := tokenlist.Values()
 	if len(values) > 0 {
-		str += fmt.Sprint(" ", strings.Join(values, ","))
+		fmt.Fprint(&b, " ", strings.Join(values, ","))
 	}
-	return str + ">"
+	b.WriteString(">")
+	return b.String()
 }

--- a/pkg/dom/tokenlist_wasm.go
+++ b/pkg/dom/tokenlist_wasm.go
@@ -1,4 +1,4 @@
-//go:build wasm
+//go:build js
 
 package dom
 

--- a/pkg/dom/window.go
+++ b/pkg/dom/window.go
@@ -60,7 +60,7 @@ func (this *window) Write(w io.Writer, node dom.Node) (int, error) {
 	case dom.DOCUMENT_TYPE_NODE:
 		var s int
 		for child := node.FirstChild(); child != nil; child = child.NextSibling() {
-			if n, err := child.(nodevalue).write(w); err != nil {
+			if n, err := writeNode(w, child); err != nil {
 				return 0, err
 			} else {
 				s += n
@@ -68,7 +68,7 @@ func (this *window) Write(w io.Writer, node dom.Node) (int, error) {
 		}
 		return s, nil
 	default:
-		return node.(nodevalue).write(w)
+		return writeNode(w, node)
 	}
 }
 

--- a/pkg/dom/window.go
+++ b/pkg/dom/window.go
@@ -72,6 +72,18 @@ func (this *window) Write(w io.Writer, node dom.Node) (int, error) {
 	}
 }
 
+// WriteIndented writes the node with indentation for better readability
+// indent is the string to use for each level (e.g., "  " or "\t")
+func (this *window) WriteIndented(w io.Writer, node dom.Node, indent string) (int, error) {
+	if node == nil {
+		return 0, dom.ErrBadParameter
+	}
+	if indent == "" {
+		indent = "  " // Default to 2 spaces
+	}
+	return writeNodeIndented(w, node, 0, indent)
+}
+
 // Read in a document from a string, and set mimetype
 func (this *window) Read(r io.Reader, mimetype string) (dom.Document, error) {
 	var node dom.Element

--- a/pkg/dom/window.go
+++ b/pkg/dom/window.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	dom "github.com/djthorpe/go-wasmbuild"
 	html "golang.org/x/net/html"
@@ -35,9 +36,11 @@ func GetWindowWithTitle(title string) dom.Window {
 // STRINGIFY
 
 func (w *window) String() string {
-	str := "<DOMWindow"
-	str += fmt.Sprint(" document=", w.document)
-	return str + ">"
+	var b strings.Builder
+	b.WriteString("<DOMWindow")
+	fmt.Fprint(&b, " document=", w.document)
+	b.WriteString(">")
+	return b.String()
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/dom/window_wasm.go
+++ b/pkg/dom/window_wasm.go
@@ -68,5 +68,13 @@ func (this *window) Write(w io.Writer, node dom.Node) (int, error) {
 	return s, nil
 }
 
+// WriteIndented writes the node's HTML with indentation (for wasm, just uses outerHTML)
+// The browser's outerHTML doesn't support custom indentation, so this is the same as Write
+func (this *window) WriteIndented(w io.Writer, node dom.Node, indent string) (int, error) {
+	// For WASM, we rely on the browser's HTML serialization
+	// which doesn't support custom indentation
+	return this.Write(w, node)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS

--- a/pkg/dom/window_wasm.go
+++ b/pkg/dom/window_wasm.go
@@ -58,7 +58,7 @@ func (this *window) Write(w io.Writer, node dom.Node) (int, error) {
 		return 0, dom.ErrBadParameter
 	}
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
-		html := child.(nodevalue).v().Get("outerHTML").String()
+		html := toJSValue(child).Get("outerHTML").String()
 		if n, err := w.Write([]byte(html)); err != nil {
 			return 0, err
 		} else {

--- a/pkg/dom/write_test.go
+++ b/pkg/dom/write_test.go
@@ -1,0 +1,304 @@
+package dom_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	domPkg "github.com/djthorpe/go-wasmbuild/pkg/dom"
+)
+
+func TestWrite_Document(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	// Add content to body
+	body := doc.Body()
+	if body != nil {
+		p := doc.CreateElement("p")
+		p.AppendChild(doc.CreateTextNode("Test content"))
+		body.AppendChild(p)
+	}
+
+	buf := new(bytes.Buffer)
+	n, err := win.Write(buf, doc)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output (%d bytes):\n%s", n, output)
+
+	// Verify DOCTYPE is present
+	if !strings.Contains(output, "<!DOCTYPE html>") {
+		t.Error("Output missing DOCTYPE")
+	}
+
+	// Verify basic structure
+	if !strings.Contains(output, "<html>") {
+		t.Error("Output missing <html>")
+	}
+
+	// Verify our added content
+	if body != nil && !strings.Contains(output, "<p>Test content</p>") {
+		t.Error("Output missing test content")
+	}
+}
+
+func TestWrite_Element(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	div := doc.CreateElement("div")
+	div.SetAttribute("class", "container")
+	div.SetAttribute("id", "main")
+	p := doc.CreateElement("p")
+	p.AppendChild(doc.CreateTextNode("Hello"))
+	div.AppendChild(p)
+
+	buf := new(bytes.Buffer)
+	_, err := win.Write(buf, div)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output: %s", output)
+
+	// Verify attributes
+	if !strings.Contains(output, "class=\"container\"") {
+		t.Error("Output missing class attribute")
+	}
+	if !strings.Contains(output, "id=\"main\"") {
+		t.Error("Output missing id attribute")
+	}
+	if !strings.Contains(output, "<p>Hello</p>") {
+		t.Error("Output missing paragraph content")
+	}
+}
+
+func TestWrite_TextNode(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	text := doc.CreateTextNode("Hello, World!")
+	buf := new(bytes.Buffer)
+	_, err := win.Write(buf, text)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	output := buf.String()
+	if output != "Hello, World!" {
+		t.Errorf("Expected 'Hello, World!', got '%s'", output)
+	}
+}
+
+func TestWrite_Comment(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	comment := doc.CreateComment("This is a comment")
+	buf := new(bytes.Buffer)
+	_, err := win.Write(buf, comment)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "<!--This is a comment-->") {
+		t.Errorf("Expected comment, got '%s'", output)
+	}
+}
+
+func TestWriteIndented_Document(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	// Add to body
+	body := doc.Body()
+	if body != nil {
+		div := doc.CreateElement("div")
+		div.SetAttribute("class", "container")
+		p := doc.CreateElement("p")
+		p.AppendChild(doc.CreateTextNode("Hello"))
+		div.AppendChild(p)
+		body.AppendChild(div)
+	}
+
+	buf := new(bytes.Buffer)
+	n, err := win.WriteIndented(buf, doc, "  ")
+	if err != nil {
+		t.Fatalf("WriteIndented failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output (%d bytes):\n%s", n, output)
+
+	// Verify indentation
+	lines := strings.Split(output, "\n")
+
+	// DOCTYPE should not be indented
+	if !strings.HasPrefix(lines[0], "<!DOCTYPE") {
+		t.Error("DOCTYPE should not be indented")
+	}
+
+	// Check that elements are indented
+	foundIndentedHead := false
+	foundIndentedBody := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "  <head>") {
+			foundIndentedHead = true
+		}
+		if strings.HasPrefix(line, "  <body>") {
+			foundIndentedBody = true
+		}
+	}
+
+	if !foundIndentedHead {
+		t.Error("Expected <head> to be indented with 2 spaces")
+	}
+	if !foundIndentedBody {
+		t.Error("Expected <body> to be indented with 2 spaces")
+	}
+}
+
+func TestWriteIndented_Tabs(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	html := doc.CreateElement("html")
+	head := doc.CreateElement("head")
+	html.AppendChild(head)
+	doc.AppendChild(html)
+
+	buf := new(bytes.Buffer)
+	_, err := win.WriteIndented(buf, doc, "\t")
+	if err != nil {
+		t.Fatalf("WriteIndented failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output:\n%s", output)
+
+	// Check for tab indentation
+	if !strings.Contains(output, "\t<head>") {
+		t.Error("Expected <head> to be indented with tab")
+	}
+}
+
+func TestWriteIndented_InlineText(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	// Elements with single text child should be on one line
+	p := doc.CreateElement("p")
+	p.AppendChild(doc.CreateTextNode("Single line text"))
+
+	buf := new(bytes.Buffer)
+	_, err := win.WriteIndented(buf, p, "  ")
+	if err != nil {
+		t.Fatalf("WriteIndented failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output: %q", output)
+
+	// Should be inline
+	if strings.Contains(output, "\n  ") {
+		t.Error("Text-only paragraph should be inline, not indented")
+	}
+	expected := "<p>Single line text</p>\n"
+	if output != expected {
+		t.Errorf("Expected %q, got %q", expected, output)
+	}
+}
+
+func TestWriteIndented_MixedContent(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	div := doc.CreateElement("div")
+	p1 := doc.CreateElement("p")
+	p1.AppendChild(doc.CreateTextNode("First"))
+	p2 := doc.CreateElement("p")
+	p2.AppendChild(doc.CreateTextNode("Second"))
+
+	div.AppendChild(p1)
+	div.AppendChild(p2)
+
+	buf := new(bytes.Buffer)
+	_, err := win.WriteIndented(buf, div, "  ")
+	if err != nil {
+		t.Fatalf("WriteIndented failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output:\n%s", output)
+
+	// Should have multiple levels of indentation
+	if !strings.Contains(output, "  <p>First</p>") {
+		t.Error("Expected indented <p> elements")
+	}
+}
+
+func TestWriteIndented_DefaultIndent(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	div := doc.CreateElement("div")
+	doc.AppendChild(div)
+
+	buf := new(bytes.Buffer)
+	// Pass empty string - should default to 2 spaces
+	_, err := win.WriteIndented(buf, div, "")
+	if err != nil {
+		t.Fatalf("WriteIndented failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output: %q", output)
+
+	// Should use default indent (tested by checking output is not empty)
+	if len(output) == 0 {
+		t.Error("Expected non-empty output")
+	}
+}
+
+func TestWriteIndented_Comment(t *testing.T) {
+	win := domPkg.GetWindow()
+	doc := win.Document()
+
+	div := doc.CreateElement("div")
+	comment := doc.CreateComment("Test comment")
+	div.AppendChild(comment)
+
+	buf := new(bytes.Buffer)
+	_, err := win.WriteIndented(buf, div, "  ")
+	if err != nil {
+		t.Fatalf("WriteIndented failed: %v", err)
+	}
+
+	output := buf.String()
+	t.Logf("Output:\n%s", output)
+
+	// Comment should be indented
+	if !strings.Contains(output, "  <!--Test comment-->") {
+		t.Error("Expected comment to be indented")
+	}
+}
+
+func TestWrite_ErrorCases(t *testing.T) {
+	win := domPkg.GetWindow()
+
+	buf := new(bytes.Buffer)
+	_, err := win.Write(buf, nil)
+	if err == nil {
+		t.Error("Expected error when writing nil node")
+	}
+
+	_, err = win.WriteIndented(buf, nil, "  ")
+	if err == nil {
+		t.Error("Expected error when writing nil node with indent")
+	}
+}


### PR DESCRIPTION
This PR refactors the pkg/dom package by eliminating the nodevalue interface in favor of explicit helper functions, improving build tag consistency, and optimizing string concatenation.

Replaces the nodevalue interface with type-switching helper functions (toJSValue, getNode, writeNode, findNextChild, findPreviousChild)
Updates build tags from wasm/!wasm to js/!js for consistency
Refactors String() methods to use strings.Builder instead of concatenation
Removes duplicate NextSibling() and PreviousSibling() implementations from leaf node types