### PR TITLE
Add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,51 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Go Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run tests
+        run: make test
+
+  jstest:
+    name: WASM Browser Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
+
+      - name: Verify Chrome installation
+        run: |
+          which google-chrome || which chromium-browser || which chromium
+          google-chrome --version || chromium-browser --version || chromium --version
+
+      - name: Run WASM tests
+        run: make jstest
+        env:
+          CHROME_BIN: /usr/bin/google-chrome


### PR DESCRIPTION
- Add two separate jobs: one for Go tests and one for WASM browser tests
- Go tests job runs 'make test' for standard unit tests
- WASM tests job runs 'make jstest' with Chrome installed for browser-based WASM testing
- Workflow triggers on push to main, pull requests, and manual dispatch
- Use Go 1.24 to match go.mod requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)