### PR TITLE
Fix Chrome sandbox issue in WASM tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,5 @@ jobs:
         run: make jstest
         env:
           CHROME_BIN: /usr/bin/google-chrome
+          CHROMEDP_NO_SANDBOX: true
+          CHROMEDP_DISABLE_GPU: true


### PR DESCRIPTION
Add CHROMEDP_NO_SANDBOX and CHROMEDP_DISABLE_GPU environment variables to allow Chrome to run in GitHub Actions CI environment without sandbox.

This resolves the "No usable sandbox!" fatal error when running wasmbrowsertest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)