### PR TITLE
Add additional Chrome flags for CI environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,29 +46,20 @@ jobs:
         with:
           chrome-version: stable
 
-      - name: Patch Chrome launcher to add --no-sandbox
+      - name: Patch Chrome launcher for CI environment
         run: |
-          echo "=== Original google-chrome launcher script ==="
-          cat /opt/google/chrome/google-chrome
-          echo "=== End of original script ==="
-
           # Backup the original launcher
           sudo cp /opt/google/chrome/google-chrome /opt/google/chrome/google-chrome.bak
 
-          # Modify the launcher to inject --no-sandbox before "$@"
-          # Try multiple patterns to catch different launcher formats
-          sudo sed -i -e 's/exec -a "$0" "$HERE\/chrome" "$@"/exec -a "$0" "$HERE\/chrome" --no-sandbox "$@"/' \
-                      -e 's/"$HERE\/chrome" "$@"/"$HERE\/chrome" --no-sandbox "$@"/' \
-                      -e 's/exec "$HERE\/chrome" "$@"/exec "$HERE\/chrome" --no-sandbox "$@"/' \
+          # Modify the launcher to inject Chrome flags needed for CI before "$@"
+          # Flags: --no-sandbox (required for CI), --disable-dev-shm-usage (CI /dev/shm is too small),
+          #        --disable-gpu (headless mode), --disable-software-rasterizer (GPU issues)
+          sudo sed -i -e 's/exec -a "$0" "$HERE\/chrome" "$@"/exec -a "$0" "$HERE\/chrome" --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer "$@"/' \
                       /opt/google/chrome/google-chrome
 
-          echo "=== Modified google-chrome launcher script ==="
-          cat /opt/google/chrome/google-chrome
-          echo "=== End of modified script ==="
-
-          echo "=== Testing modified launcher ==="
+          echo "Modified exec line:"
+          tail -1 /opt/google/chrome/google-chrome
           google-chrome --version
-          echo "=== Test complete ==="
 
       - name: Run WASM tests
         run: make jstest


### PR DESCRIPTION
Added --disable-dev-shm-usage, --disable-gpu, and --disable-software-rasterizer to fix "websocket url timeout reached" error. These flags are commonly needed in CI environments for headless Chrome to work properly.

- --disable-dev-shm-usage: CI environments have limited /dev/shm
- --disable-gpu: Required for headless mode stability
- --disable-software-rasterizer: Helps with GPU-related issues

Simplified debugging output now that we've confirmed sed is working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)