### PR TITLE
Added license, and updated readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -172,30 +172,3 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+# NOTICE
+
+Copyright 2025 David Thorpe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,97 +1,53 @@
 # go-wasmbuild
 
-**wasmbuild** is a command-line tool for compiling applications in the Go programming language ("golang") into
-[WASM](https://webassembly.org/) so they can be run in a web browser.
+**wasmbuild** is a command-line tool for compiling applications from the Go programming language ("golang") into
+[WASM](https://webassembly.org/) so they can be run as web applications in a browser.
 
 It provides a development environment so you can test your code as you
-develop it. There are also various packages which implement bridges to the web browser runtime, and several
-popular JavaScript libtaties, so you can - for example - create reactive web components in your golang
-application.
+develop it. There are packages for several
+popular JavaScript libraries, so you can - for example - create reactive web components in golang.
 
-> *Experimental!* Please note this repository contains code which depends on experimental features of the Go language,
-> and is also a very rough and ready implementation itself.
-
-## Overview
+> *Experimental!* Please note this repository contains code which depends on experimental features of the Go language.
 
 This repository provides three main components:
 
 1. **WASM Build Server** (`cmd/wasmbuild`) - A feature-rich development server for building and serving golang WASM
    applications with live reload, error notifications, and automatic dependency watching
 2. **DOM Package** (`pkg/dom`) - A Go implementation of the Document Object Model (DOM) API that works both natively and in WASM environments
-3. **Bootstrap 5 Package** (`pkg/bs5`) - Experimental Go wrappers for Bootstrap 5 components (very rough and ready)
+3. **Bootstrap 5 Package** (`pkg/bootstrap`) - Go wrappers for Bootstrap 5 components
 
-There are also some examples of developing front-end applications in the `cmd/wasm` folder.
+There are also some examples of developing front-end applications in the `wasm` folder.
 
 ## WASM Build Server
 
-The `wasmbuild` tool provides a modern development experience for WASM applications written in Go:
+The `wasmbuild` tool provides a modern development experience for WASM applications written in Go. Please see [the documentation for `wasmbuild`](cmd/wasmbuild/README.md) for full details.
+
+Example usage:
+
+```bash
+# Install wasmbuild
+go install github.com/djthorpe/go-wasmbuild/cmd/wasmbuild
+
+# Start the wasmbuild server, watch for changes
+wasmbuild serve -w path/to/your/go/project
+
+# Navigate to http://localhost:8080 in your browser for development
+
+# Build a production version of your app
+wasmbuild build -o ./dist path/to/your/go/project
+```
 
 ### Features
 
 - **Compile golang to WASM** - Seamlessly compiles Go applications to WebAssembly
 - **Serve WASM Applications** - Hosts your WASM apps with a built-in HTTP server, including serving the bootstrap HTML and JS needed to run Go WASM applications
-- **Bootstrap 5 Support** - Optional `--bs-5` flag includes Bootstrap 5 CSS, JavaScript, and Icons in the HTML template
 - **Automatic Dependency Discovery** - Watches all local package dependencies (no manual configuration needed)
-- **Server-Sent Events (SSE)** - Efficient communication between server and browser
 - **Live Reload** - Automatically recompiles and reloads the browser when source files change
 - **Real-time Error Display** - Compilation errors appear directly in the browser with full error messages
 
-### Quick Start
+## Bootstrap
 
-Build the wasmbuild to the `build/` directory:
-
-```bash
-make wasmbuild
-```
-
-Serve your WASM application with live reload:
-
-```bash
-./build/wasmbuild serve --watch ./cmd/wasm/helloworld
-```
-
-Or compile without serving, which also copies the required bootstrapping assets into the build folder:
-
-```bash
-./build/wasmbuild compile ./cmd/wasm/helloworld
-```
-
-### Usage
-
-```bash
-# Serve with live reload (discovers and watches local dependencies automatically)
-./build/wasmbuild serve --watch <path-to-wasm-app>
-
-# Serve with Bootstrap 5 support (includes Bootstrap CSS/JS in the HTML)
-./build/wasmbuild serve --watch --bs-5 <path-to-wasm-app>
-
-# Serve with verbose logging
-./build/wasmbuild serve --verbose --watch <path-to-wasm-app>
-
-# Compile to a specific output directory
-./build/wasmbuild compile --output ./build <path-to-wasm-app>
-
-# Custom listen address
-./build/wasmbuild serve --listen 0.0.0.0:8080 <path-to-wasm-app>
-```
-
-The server automatically:
-
-- Discovers all local package dependencies using `go list`
-- Watches the main application and all dependent packages for changes
-- Recompiles when any `.go` file changes
-- Sends compilation errors to the browser in real-time
-- Triggers browser reload on successful compilation
-
-## Bootstrap 5 Package (Experimental)
-
-> **Note:** The Bootstrap 5 wrapper (`pkg/bs5`) is very rough and ready. It provides
-> Go bindings for Bootstrap 5 components but is not production-ready and should be
-> considered experimental.
-
-The `pkg/bs5` package provides Go wrappers for Bootstrap 5 components, allowing you to build
-Bootstrap-based web applications in Go/WASM. A comprehensive demo application showcasing all
-components is available in `cmd/wasm/bootstrap-app`.
+The `pkg/bootstrap` package provides Go wrappers for Bootstrap 5 components, allowing you to build Bootstrap-based web applications in Go/WASM. A comprehensive demo application showcasing all components is available in `wasm/bootstrap-app`.
 
 ### Bootstrap Components
 
@@ -106,86 +62,30 @@ components is available in `cmd/wasm/bootstrap-app`.
 - Form controls with validation
 - Bootstrap Icons integration
 
-### Bootstrap Quick Start
-
-Build and run the Bootstrap demo, which demonstrates all the components which can be created using the `pkg/bs5` package:
-
-```bash
-./build/wasmbuild serve --watch ./cmd/wasm/bootstrap-app --bs-5
-```
-
-See [`cmd/wasm/bootstrap-app/README.md`](cmd/wasm/bootstrap-app/README.md) for detailed documentation.
-
-## DOM Package
-
-Implements the document object model (DOM) for Go - which is
-runnable both in a native go environment or via a web browser
-when compiling for WASM target.
-
-Presently go version 1.24 has been tested. [Tinygo](https://tinygo.org/) should
-eventually be supported in order to facilitate smaller binary sizes.
-
-### Hello, World
-
-In order to access the current HTML document, access the `window` object. You
-can dump the current document contents from the root element, or set the
-title of the document:
-
-```go
-package main
-
-import (
-  . "github.com/djthorpe/go-dom/pkg/dom"
-)
-
-func main() {
-  window := GetWindow()
-  window.Document().SetTitle("Hello, World!")
-  fmt.Println(window.Document().DocumentElement().OuterHTML())
-}
-```
-
-To compile and run this example natively, run:
-
-```bash
-git clone git@github.com:djthorpe/go-dom.git
-cd go-dom
-go run ./cmd/wasm/helloworld
-```
-
-To run this within a web browser, you'll need to compile it to WASM instead:
-
-```bash
-git clone git@github.com:djthorpe/go-dom.git
-cd go-dom
-GOOS=js GOARCH=wasm go build -o build/helloworld.wasm ./cmd/wasm/helloworld
-```
-
-See the [WebAssembly documentation](https://go.dev/wiki/WebAssembly) for running
-WASM within a web browser. There is some helper code which allows you to run it
-from the command line:
-
-```bash
-git clone git@github.com:djthorpe/go-dom.git
-cd go-dom
-make wasmbuild
-./build/wasmbuild serve cmd/wasm/helloworld
-```
-
-Then you can simply view the page at <http://localhost:9090/> and check the console log to see the output.
-
 ## Running Tests
 
-(TODO)
-
-You should run tests both in the native go environment and in the WASM
-environment. For the latter, Google Chrome needs to be installed (other browsers
-may work but have not been tested). The commands for testing are:
+You can run tests both in the native go environment and in the WASM
+environment.  The commands for testing are:
 
 ```bash
-git clone git@github.com:djthorpe/go-dom.git
-cd go-dom
-make test && make jstest
+git clone git@github.com:djthorpe/go-wasmbuild.git
+cd go-wasmbuild
+# Test in native go environment
+make test
+# Test in browser environment
+make jstest
 ```
 
 Testing in a WASM environment uses [wasmbrowsertest](https://github.com/agnivade/wasmbrowsertest). Please see the documentation for that package for more information on testing in the WASM environment and browser support.
+
+## License
+
+This project is licensed under the Apache License, Version 2.0. The Apache License is a permissive free software license that:
+
+- **Allows** commercial use, modification, distribution, and private use
+- **Requires** preservation of copyright and license notices, and inclusion of a NOTICE file if one exists
+- **Provides** an express grant of patent rights from contributors to users
+- **Does not** provide trademark rights or warranties
+- **Requires** stating significant changes made to the software
+
+For the complete license terms, see the [LICENSE](LICENSE) file or visit <http://www.apache.org/licenses/LICENSE-2.0>.

--- a/etc/wasm_exec.html
+++ b/etc/wasm_exec.html
@@ -5,7 +5,6 @@
     <title>{{Title}}</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- bootstrap the application -->
     <script src="wasm_exec.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
@@ -15,7 +14,6 @@
             });
         });
     </script>
-    <!-- additional head components -->
     <link rel="icon" type="image/png" href="favicon.png" />
     {{Notify}}
     {{Header}}


### PR DESCRIPTION
This PR adds licensing information and updates the project documentation. The main changes include adding proper Apache 2.0 license files and significantly reorganizing the README to be more concise and user-friendly.

Key changes:

* Added Apache 2.0 license with NOTICE file
* Streamlined README with clearer structure and updated package references
* Removed redundant HTML comments from the WASM execution template