### PR TITLE
Djt/1119/toasts

### DIFF
--- a/pkg/bootstrap/color.go
+++ b/pkg/bootstrap/color.go
@@ -132,6 +132,8 @@ func colorPrefixForView(name string) string {
 		return "text-bg"
 	case ViewCard:
 		return "text-bg"
+	case ViewToast:
+		return "text-bg"
 	case ViewLink:
 		return "link"
 	case ViewButton:

--- a/pkg/bootstrap/extra/pagination_controller.go
+++ b/pkg/bootstrap/extra/pagination_controller.go
@@ -1,0 +1,92 @@
+package extra
+
+import (
+	// Packages
+	"fmt"
+
+	bs "github.com/djthorpe/go-wasmbuild/pkg/bootstrap"
+	mvc "github.com/djthorpe/go-wasmbuild/pkg/mvc"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type pagination_controller struct {
+	mvc.Controller
+
+	// Pagination state
+	offset, limit, count uint
+}
+
+var _ mvc.Controller = (*pagination_controller)(nil)
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+func PaginationController(view mvc.View) *pagination_controller {
+	// Check view is a Pagination view
+	if view == nil || view.Name() != bs.ViewPagination {
+		panic("Invalid view for PaginationController")
+	}
+
+	// Create controller and return it
+	return mvc.NewController(new(pagination_controller), view).Self().(*pagination_controller)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS - CONTROLLER
+
+func (c *pagination_controller) Attach(views ...mvc.View) {
+	panic("Attach not implemented for PaginationController")
+}
+
+func (c *pagination_controller) Detach(views ...mvc.View) {
+	panic("Detach not implemented for PaginationController")
+}
+
+func (c *pagination_controller) EventListener(event string, view mvc.View) {
+	fmt.Println("PaginationController: Event", event, "from view", view.Name())
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Set the current offset, limit and count and update the pagination state
+func (c *pagination_controller) Set(offset, limit, count uint) {
+	c.offset = offset
+	c.limit = limit
+	c.count = count
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS
+
+// Return the number of pages. Can return 0 if the number of pages
+// cannot be determined
+func (c *pagination_controller) Num() uint {
+	// If we don't have a limit (page size) then return 0
+	if c.limit == 0 {
+		return 0
+	}
+	// If we have a count, return number of pages based on limit
+	if c.count > 0 {
+		if c.count%c.limit == 0 {
+			return c.count / c.limit
+		} else {
+			return (c.count / c.limit) + 1
+		}
+	}
+	// If we don't have a count, then return offset/limit + 1
+	return (c.offset / c.limit) + 1
+}
+
+// Return the current page number. Can return 0 if the current page
+// cannot be determined
+func (c *pagination_controller) Cur() uint {
+	// If we don't have a limit (page size) then return 0
+	if c.limit == 0 {
+		return 0
+	}
+	// Return current page based on offset/limit
+	return (c.offset / c.limit) + 1
+}

--- a/pkg/bootstrap/pagination.go
+++ b/pkg/bootstrap/pagination.go
@@ -17,11 +17,16 @@ type pagination struct {
 	mvc.View
 }
 
+type paginationitem struct {
+	mvc.View
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // GLOBALS
 
 const (
-	ViewPagination = "mvc-bs-pagination"
+	ViewPagination     = "mvc-bs-pagination"
+	ViewPaginationItem = "mvc-bs-paginationitem"
 )
 
 const (
@@ -29,12 +34,13 @@ const (
 		<nav><ul class="pagination" data-slot></ul></nav>	
 	`
 	templatePaginationItem = `
-		<li class="page-item"><a class="page-link" href="#"></a></li>
+		<li class="page-item"><a class="page-link" role="button" data-slot></a></li>
 	`
 )
 
 func init() {
 	mvc.RegisterView(ViewPagination, newPaginationFromElement)
+	mvc.RegisterView(ViewPaginationItem, newPaginationItemFromElement)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,11 +50,22 @@ func Pagination(args ...any) *pagination {
 	return mvc.NewViewExEx(new(pagination), ViewPagination, templatePagination, args).(*pagination)
 }
 
+func PaginationItem(args ...any) *paginationitem {
+	return mvc.NewViewExEx(new(paginationitem), ViewPaginationItem, templatePaginationItem, args).(*paginationitem)
+}
+
 func newPaginationFromElement(element Element) mvc.View {
 	if element.TagName() != "NAV" {
 		return nil
 	}
 	return mvc.NewViewWithElement(new(pagination), element)
+}
+
+func newPaginationItemFromElement(element Element) mvc.View {
+	if element.TagName() != "LI" {
+		return nil
+	}
+	return mvc.NewViewWithElement(new(paginationitem), element)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -58,15 +75,21 @@ func (pagination *pagination) SetView(view mvc.View) {
 	pagination.View = view
 }
 
+func (paginationitem *paginationitem) SetView(view mvc.View) {
+	paginationitem.View = view
+}
+
 func (pagination *pagination) Content(args ...any) mvc.View {
 	for i, arg := range args {
 		switch arg := arg.(type) {
 		case string:
-			args[i] = mvc.HTML(templatePaginationItem, arg)
+			args[i] = PaginationItem(arg)
 		case dom.Element:
-			args[i] = mvc.HTML(templatePaginationItem, arg)
+			args[i] = PaginationItem(arg)
+		case *paginationitem:
+			// No-op
 		case mvc.View:
-			args[i] = mvc.HTML(templatePaginationItem, arg)
+			args[i] = PaginationItem(arg)
 		default:
 			panic(ErrInternalAppError.Withf("Content[pagination] unexpected argument '%T'", arg))
 		}

--- a/pkg/bootstrap/pagination.go
+++ b/pkg/bootstrap/pagination.go
@@ -39,7 +39,10 @@ const (
 )
 
 func init() {
-	mvc.RegisterView(ViewPagination, newPaginationFromElement)
+	// Pagination listens for "click" events
+	mvc.RegisterView(ViewPagination, func(element Element) mvc.View {
+		return mvc.NewViewWithElement(new(pagination), element)
+	}, "click")
 	mvc.RegisterView(ViewPaginationItem, newPaginationItemFromElement)
 }
 

--- a/pkg/bootstrap/state.go
+++ b/pkg/bootstrap/state.go
@@ -13,14 +13,21 @@ import (
 // WithDisabled adds a disabled attribute to a view
 func WithDisabled(disabled bool) mvc.Opt {
 	return func(o mvc.OptSet) error {
-		//  && o.Name() != ViewNavItem
-		if o.Name() != ViewButton {
+		switch o.Name() {
+		case ViewButton:
+			if disabled {
+				return mvc.WithAttr("disabled", "disabled")(o)
+			} else {
+				return mvc.WithoutAttr("disabled")(o)
+			}
+		case ViewPaginationItem:
+			if disabled {
+				return mvc.WithClass("disabled")(o)
+			} else {
+				return mvc.WithoutClass("disabled")(o)
+			}
+		default:
 			return fmt.Errorf("WithDisabled: invalid view type %q", o.Name())
-		}
-		if disabled {
-			return mvc.WithAttr("disabled", "disabled")(o)
-		} else {
-			return mvc.WithoutAttr("disabled")(o)
 		}
 	}
 }
@@ -28,14 +35,15 @@ func WithDisabled(disabled bool) mvc.Opt {
 // WithActive adds an active attribute to a view
 func WithActive(active bool) mvc.Opt {
 	return func(o mvc.OptSet) error {
-		//  && o.Name() != ViewNavItem
-		if o.Name() != ViewButton {
+		switch o.Name() {
+		case ViewButton, ViewPaginationItem:
+			if active {
+				return mvc.WithClass("active")(o)
+			} else {
+				return mvc.WithoutClass("active")(o)
+			}
+		default:
 			return fmt.Errorf("WithActive: invalid view type %q", o.Name())
-		}
-		if active {
-			return mvc.WithClass("active")(o)
-		} else {
-			return mvc.WithoutClass("active")(o)
 		}
 	}
 }

--- a/pkg/bootstrap/toast.go
+++ b/pkg/bootstrap/toast.go
@@ -1,0 +1,114 @@
+package bootstrap
+
+import (
+	// Packages
+	js "github.com/djthorpe/go-wasmbuild/pkg/js"
+	mvc "github.com/djthorpe/go-wasmbuild/pkg/mvc"
+
+	// Namespace imports
+	. "github.com/djthorpe/go-wasmbuild"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type toast struct {
+	mvc.View
+}
+
+type toastgroup struct {
+	mvc.View
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// GLOBALS
+
+const (
+	ViewToast      = "mvc-bs-toast"
+	ViewToastGroup = "mvc-bs-toastgroup"
+)
+
+const (
+	templateToast = `
+		<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+			<slot name="header"></slot>
+			<slot></slot>
+		</div>
+	`
+)
+
+func init() {
+	mvc.RegisterView(ViewToast, newToastFromElement)
+	mvc.RegisterView(ViewToastGroup, newToastGroupFromElement)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+func Toast(name string, args ...any) *toast {
+	return mvc.NewViewExEx(new(toast), ViewToast, templateToast, mvc.WithID(name), args).(*toast)
+}
+
+func ToastGroup(args ...any) *toastgroup {
+	return mvc.NewView(new(toastgroup), ViewToastGroup, "DIV", mvc.WithClass("toast-container", "position-static"), args).(*toastgroup)
+}
+
+func newToastFromElement(element Element) mvc.View {
+	if element.TagName() != "DIV" {
+		return nil
+	}
+	return mvc.NewViewWithElement(new(toast), element)
+}
+
+func newToastGroupFromElement(element Element) mvc.View {
+	if element.TagName() != "DIV" {
+		return nil
+	}
+	return mvc.NewViewWithElement(new(toastgroup), element)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+func (toast *toast) SetView(view mvc.View) {
+	toast.View = view
+}
+
+func (toastgroup *toastgroup) SetView(view mvc.View) {
+	toastgroup.View = view
+}
+
+func (toast *toast) Header(args ...any) mvc.View {
+	return toast.ReplaceSlot("header", mvc.HTML("DIV", mvc.WithClass("toast-header"), args))
+}
+
+func (toast *toast) Content(args ...any) mvc.View {
+	return toast.ReplaceSlot("", mvc.HTML("DIV", mvc.WithClass("toast-body"), args))
+}
+
+func (toast *toast) Show() mvc.ViewWithVisibility {
+	// TODO: Clear issues for non-wasm builds
+	if j := js.GetProto("bootstrap.Toast"); j.IsUndefined() {
+		panic("bootstrap.Toast is undefined")
+	} else {
+		j.New("#" + toast.ID()).Call("show")
+	}
+	return toast
+
+}
+
+func (toast *toast) Hide() mvc.ViewWithVisibility {
+	// TODO: Clear issues for non-wasm builds
+	if j := js.GetProto("bootstrap.Toast"); j.IsUndefined() {
+		panic("bootstrap.Toast is undefined")
+	} else {
+		j.New("#" + toast.ID()).Call("hide")
+	}
+	return toast
+
+}
+
+func (toast *toast) Visible() bool {
+	// TODO
+	return false
+}

--- a/pkg/mvc/controller.go
+++ b/pkg/mvc/controller.go
@@ -1,0 +1,96 @@
+package mvc
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	dom "github.com/djthorpe/go-wasmbuild"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// A controller reacts to events from one or more views
+type Controller interface {
+	// Attach one or more views to this controller
+	Attach(...View)
+
+	// Detach one or more views from this controller
+	Detach(...View)
+
+	// Fire an action based on an event from a view
+	EventListener(string, View)
+}
+
+type controller struct {
+	self  Controller
+	views []View
+}
+
+var _ Controller = (*controller)(nil)
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+func NewController(self Controller, view ...View) *controller {
+	this := new(controller)
+	this.self = self
+	this.Attach(view...)
+	return this
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS - CONTROLLER
+
+func (c *controller) Attach(views ...View) {
+	// Attach all views to the controller
+	for _, view := range views {
+		if view == nil || slices.Contains(c.views, view) {
+			continue
+		}
+		c.views = append(c.views, view)
+
+		// Add event listeners for this view
+		for _, event := range events[view.Name()] {
+			view.AddEventListener(event, func(evt dom.Event) {
+				if view := ViewFromEvent(evt); view != nil {
+					c.Self().EventListener(event, view)
+				}
+			})
+		}
+	}
+}
+
+func (c *controller) Detach(views ...View) {
+	// Detach all views from the controller
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		for i, v := range c.views {
+			if v == view {
+				// Remove event listeners for this view
+				for _, event := range events[view.Name()] {
+					view.RemoveEventListener(event)
+				}
+
+				// Remove from slice
+				c.views = append(c.views[:i], c.views[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+func (c *controller) EventListener(event string, view View) {
+	fmt.Fprintf(os.Stderr, "Self %T", c.Self())
+	fmt.Fprintf(os.Stderr, "Controller: EventListener not implemented for event %q from view %q\n", event, view.Name())
+}
+
+func (c *controller) Self() Controller {
+	if c.self == nil {
+		return c
+	}
+	return c.self
+}

--- a/pkg/mvc/controller.go
+++ b/pkg/mvc/controller.go
@@ -53,9 +53,10 @@ func (c *controller) Attach(views ...View) {
 
 		// Add event listeners for this view
 		for _, event := range events[view.Name()] {
-			view.AddEventListener(event, func(evt dom.Event) {
+			e := event // capture loop variable
+			view.AddEventListener(e, func(evt dom.Event) {
 				if view := ViewFromEvent(evt); view != nil {
-					c.Self().EventListener(event, view)
+					c.Self().EventListener(e, view)
 				}
 			})
 		}

--- a/pkg/mvc/router.go
+++ b/pkg/mvc/router.go
@@ -41,7 +41,9 @@ const (
 )
 
 func init() {
-	RegisterView(ViewRouter, newRouterFromElement)
+	RegisterView(ViewRouter, func(element wasm.Element) View {
+		return NewViewWithElement(new(router), element)
+	})
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/mvc/view.go
+++ b/pkg/mvc/view.go
@@ -35,6 +35,9 @@ type View interface {
 	// Add an event listener to the view's root element
 	AddEventListener(string, func(dom.Event)) View
 
+	// Remove an event listener from the view's root element
+	RemoveEventListener(string) View
+
 	// Return the value of the view as a string. The contents of the
 	// string depends on the view type
 	Value() string
@@ -141,15 +144,20 @@ const (
 var (
 	// All the registered views
 	views = make(map[string]ViewConstructorFunc, 50)
+
+	// All the registered events
+	events = make(map[string][]string, 50)
 )
 
 // RegisterView registers a view constructor function for a given name,
-// so that the view can be created on-demand
-func RegisterView(name string, constructor ViewConstructorFunc) {
+// so that the view can be created on-demand, and zero or more event types that
+// a controller which attaches to this view should listen for.
+func RegisterView(name string, constructor ViewConstructorFunc, eventtypes ...string) {
 	if _, exists := views[name]; exists {
 		panic("View already registered: " + name)
 	}
 	views[name] = constructor
+	events[name] = eventtypes
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -472,6 +480,11 @@ func (v *view) Label(children ...any) View {
 
 func (v *view) AddEventListener(event string, handler func(dom.Event)) View {
 	v.root.AddEventListener(event, handler)
+	return v.self
+}
+
+func (v *view) RemoveEventListener(event string) View {
+	v.root.RemoveEventListener(event)
 	return v.self
 }
 

--- a/wasm/bootstrap-app/embed.go
+++ b/wasm/bootstrap-app/embed.go
@@ -77,6 +77,6 @@ func Example(fn func() (mvc.View, string)) mvc.View {
 	source = strings.ReplaceAll(source, "\t", "  ")
 	return bs.Container(
 		view,
-		bs.CodeBlock(source, bs.WithColor(bs.Light), bs.WithBorder(), mvc.WithClass("mt-3", "p-3"), mvc.WithStyle("font-size: 0.75em; overflow-x: auto")),
+		bs.CodeBlock(source, bs.WithBorder(), mvc.WithClass("mt-3", "p-3"), mvc.WithStyle("font-size: 0.75em; overflow-x: auto")),
 	)
 }

--- a/wasm/bootstrap-app/main.go
+++ b/wasm/bootstrap-app/main.go
@@ -20,7 +20,8 @@ func main() {
 			bs.NavDropdown(
 				bs.NavItem("#button", "Buttons"),
 				bs.NavItem("#modal", "Modal"),
-				bs.NavItem("#alert", "Alerts & Toasts"),
+				bs.NavItem("#alert", "Alerts"),
+				bs.NavItem("#toast", "Toasts"),
 			).Label("Interactivity"),
 			bs.NavDropdown(
 				bs.NavItem("#input", "Input"),
@@ -29,7 +30,7 @@ func main() {
 				bs.NavItem("#navbar", "Navbar"),
 				bs.NavItem("#nav", "Accordion"),
 				bs.NavItem("#nav", "Navigation"),
-				bs.NavItem("#nav", "Pagination"),
+				bs.NavItem("#pagination", "Pagination"),
 			).Label("Navigation"),
 			bs.NavDropdown(
 				bs.NavItem("#border", "Borders"),
@@ -56,10 +57,11 @@ func main() {
 			Page("#progress", ProgressExamples()).
 			Page("#navbar", NavBarExamples()).
 			Page("#nav", NavExamples()).
+			Page("#pagination", PaginationExamples()).
 			Page("#table", TableExamples()).
-			Page("#alert", AlertExamples()),
+			Page("#alert", AlertExamples()).
+			Page("#toast", ToastExamples()),
 	)
-
 	// Wait
 	select {}
 }

--- a/wasm/bootstrap-app/nav_examples.go
+++ b/wasm/bootstrap-app/nav_examples.go
@@ -10,15 +10,10 @@ func NavExamples() mvc.View {
 	return bs.Container(
 		mvc.WithClass("my-4"),
 		bs.Heading(2, "Navigation Examples"), bs.HRule(),
-		bs.Heading(3, "Pagination", mvc.WithClass("mt-5")), Example(Example_Pagination_001),
 		bs.Heading(3, "Accordion", mvc.WithClass("mt-5")), Example(Example_Accordion_001),
 		bs.Heading(3, "Flush Accordion", mvc.WithClass("mt-5")), Example(Example_Accordion_002),
 		bs.Heading(3, "Dark Accordion", mvc.WithClass("mt-5")), Example(Example_Accordion_003),
 	)
-}
-
-func Example_Pagination_001() (mvc.View, string) {
-	return bs.Pagination("Prev", "1", "2", "...", "3", "Next"), sourcecode()
 }
 
 func Example_Accordion_001() (mvc.View, string) {

--- a/wasm/bootstrap-app/pagination_examples.go
+++ b/wasm/bootstrap-app/pagination_examples.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	// Packages
+	dom "github.com/djthorpe/go-wasmbuild"
+	bs "github.com/djthorpe/go-wasmbuild/pkg/bootstrap"
+	mvc "github.com/djthorpe/go-wasmbuild/pkg/mvc"
+)
+
+func PaginationExamples() mvc.View {
+	return bs.Container(
+		mvc.WithClass("my-4"),
+		bs.Heading(2, "Pagination Examples"), bs.HRule(),
+		bs.Heading(3, "Pagination", mvc.WithClass("mt-5")), Example(Example_Pagination_001),
+		bs.Heading(3, "Events", mvc.WithClass("mt-5")), Example(Example_Pagination_002),
+	)
+}
+
+func Example_Pagination_001() (mvc.View, string) {
+	return bs.Pagination(
+		"Prev", "1", "2",
+		bs.PaginationItem("...", bs.WithDisabled(true)),
+		bs.PaginationItem("3", bs.WithActive(true)),
+		"Next",
+	), sourcecode()
+}
+
+func Example_Pagination_002() (mvc.View, string) {
+	response := bs.Para("Click on a pagination item")
+	return bs.Container(
+		response,
+		bs.Pagination(
+			"Prev", "1", "2",
+			bs.PaginationItem("...", bs.WithDisabled(true)),
+			bs.PaginationItem("3", bs.WithActive(true)),
+			"Next",
+		).AddEventListener("click", func(e dom.Event) {
+			view := mvc.ViewFromEvent(e)
+			if view.Name() == bs.ViewPaginationItem {
+				response.Content(bs.Code(view.Root().TextContent()), " clicked")
+			} else {
+				response.Content()
+			}
+		})), sourcecode()
+}

--- a/wasm/bootstrap-app/pagination_examples.go
+++ b/wasm/bootstrap-app/pagination_examples.go
@@ -13,6 +13,7 @@ func PaginationExamples() mvc.View {
 		bs.Heading(2, "Pagination Examples"), bs.HRule(),
 		bs.Heading(3, "Pagination", mvc.WithClass("mt-5")), Example(Example_Pagination_001),
 		bs.Heading(3, "Events", mvc.WithClass("mt-5")), Example(Example_Pagination_002),
+		bs.Heading(3, "Icons & Theme", mvc.WithClass("mt-5")), Example(Example_Pagination_003),
 	)
 }
 
@@ -42,4 +43,15 @@ func Example_Pagination_002() (mvc.View, string) {
 				response.Content()
 			}
 		})), sourcecode()
+}
+
+func Example_Pagination_003() (mvc.View, string) {
+	return bs.Pagination(
+		bs.Icon("arrow-left"),
+		"1", "2", "3",
+		bs.PaginationItem("4", bs.WithActive(true)),
+		"5",
+		bs.Icon("arrow-right"),
+		bs.WithTheme(bs.Dark),
+	), sourcecode()
 }

--- a/wasm/bootstrap-app/pagination_examples.go
+++ b/wasm/bootstrap-app/pagination_examples.go
@@ -4,6 +4,7 @@ import (
 	// Packages
 	dom "github.com/djthorpe/go-wasmbuild"
 	bs "github.com/djthorpe/go-wasmbuild/pkg/bootstrap"
+	bsextra "github.com/djthorpe/go-wasmbuild/pkg/bootstrap/extra"
 	mvc "github.com/djthorpe/go-wasmbuild/pkg/mvc"
 )
 
@@ -14,6 +15,7 @@ func PaginationExamples() mvc.View {
 		bs.Heading(3, "Pagination", mvc.WithClass("mt-5")), Example(Example_Pagination_001),
 		bs.Heading(3, "Events", mvc.WithClass("mt-5")), Example(Example_Pagination_002),
 		bs.Heading(3, "Icons & Theme", mvc.WithClass("mt-5")), Example(Example_Pagination_003),
+		bs.Heading(3, "Controller", mvc.WithClass("mt-5")), Example(Example_Pagination_004),
 	)
 }
 
@@ -54,4 +56,22 @@ func Example_Pagination_003() (mvc.View, string) {
 		bs.Icon("arrow-right"),
 		bs.WithTheme(bs.Dark),
 	), sourcecode()
+}
+
+func Example_Pagination_004() (mvc.View, string) {
+	// Create the pagination view
+	view := bs.Pagination(
+		bs.Icon("arrow-left"),
+		"1", "2", "3",
+		bs.PaginationItem("4", bs.WithActive(true)),
+		"5",
+		bs.Icon("arrow-right"),
+		bs.WithTheme(bs.Dark),
+	)
+
+	// Create controller and attach the pagination view
+	bsextra.PaginationController(view)
+
+	// Return the view for display
+	return view, sourcecode()
 }

--- a/wasm/bootstrap-app/toast_examples.go
+++ b/wasm/bootstrap-app/toast_examples.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	// Packages
+	"fmt"
+
+	dom "github.com/djthorpe/go-wasmbuild"
+	bs "github.com/djthorpe/go-wasmbuild/pkg/bootstrap"
+	mvc "github.com/djthorpe/go-wasmbuild/pkg/mvc"
+)
+
+func ToastExamples() mvc.View {
+	return bs.Container(
+		mvc.WithClass("my-4"),
+		bs.Heading(2, "Toast Examples"), bs.HRule(),
+		bs.Heading(3, "Toast", mvc.WithClass("mt-5")), Example(Example_Toast_001),
+		bs.Heading(3, "Color", mvc.WithClass("mt-5")), Example(Example_Toast_002),
+		bs.Heading(3, "Toast Group", mvc.WithClass("mt-5")), Example(Example_Toast_003),
+	)
+}
+
+func Example_Toast_001() (mvc.View, string) {
+	toast := bs.Toast(
+		"toast-001", "Hello, world! This is a toast message.",
+		mvc.WithClass("my-3"),
+	).Header(
+		bs.Strong("Toast Header", mvc.WithClass("me-auto")),
+		bs.CloseButton(mvc.WithAttr("data-bs-dismiss", "toast")),
+	).(mvc.ViewWithVisibility)
+
+	return bs.Container(
+		toast,
+		bs.Button("Show Toast").AddEventListener("click", func(e dom.Event) {
+			toast.Show()
+		}),
+	), sourcecode()
+}
+
+func Example_Toast_002() (mvc.View, string) {
+	toast := bs.Toast(
+		"toast-002",
+		bs.Icon("bell-fill", mvc.WithClass("me-2")),
+		"Hello, world! This is a toast message.",
+		bs.WithColor(bs.Primary),
+		mvc.WithClass("my-3"),
+	)
+
+	return bs.Container(
+		toast,
+		bs.Button("Show Toast").AddEventListener("click", func(e dom.Event) {
+			toast.Show()
+		}),
+	), sourcecode()
+}
+
+func Example_Toast_003() (mvc.View, string) {
+	toast3 := bs.Toast(
+		"toast-003-1",
+		bs.Icon("bell-fill", mvc.WithClass("me-2")),
+		"Hello, world! This is a toast message.",
+		bs.WithColor(bs.Warning),
+		mvc.WithClass("my-3"),
+	)
+	toast4 := bs.Toast(
+		"toast-003-2",
+		bs.Icon("exclamation-octagon-fill", mvc.WithClass("me-2")),
+		"Hello, world! This is a toast message.",
+		bs.WithColor(bs.Danger),
+		mvc.WithClass("my-3"),
+	)
+	group := bs.ToastGroup(toast3, toast4)
+	position := bs.Select("select-003",
+		bs.Option("None", ""),
+		bs.Option("Top Left", "top-0 start-0"),
+		bs.Option("Top Right", "top-0 end-0"),
+		bs.Option("Bottom Left", "bottom-0 start-0"),
+		bs.Option("Bottom Right", "bottom-0 end-0"),
+	).AddEventListener("input", func(e dom.Event) {
+		v := mvc.ViewFromEvent(e)
+		switch v.Value() {
+		case "":
+			group.Apply(mvc.WithoutClass("position-absolute", "top-0", "bottom-0", "start-0", "end-0"))
+			group.Apply(mvc.WithClass("position-static"))
+		default:
+			group.Apply(mvc.WithoutClass("position-static", "top-0", "bottom-0", "start-0", "end-0"))
+			group.Apply(mvc.WithClass("position-absolute", v.Value()))
+		}
+		fmt.Printf("Selected position: %q\n", group.Root().ClassList().Values())
+	})
+
+	return bs.Container(
+		group,
+		bs.Container(
+			bs.Button("Show Notification", mvc.WithClass("me-2")).AddEventListener("click", func(e dom.Event) {
+				toast3.Show()
+			}),
+			bs.Button("Show Error", mvc.WithClass("me-2")).AddEventListener("click", func(e dom.Event) {
+				toast4.Show()
+			}),
+			position,
+			bs.WithFlex(bs.End),
+		),
+	), sourcecode()
+}


### PR DESCRIPTION
This PR introduces Toast components and refactors the Pagination component to support a new MVC controller pattern. The changes split pagination examples into a dedicated file and add comprehensive toast examples with interactive functionality.

* Adds new Toast component with visibility controls (Show/Hide) and group support
* Introduces a generic Controller interface in the MVC package for event-driven view interactions
* Refactors Pagination component to support event registration, active/disabled states, and controller attachment
* Reorganizes navigation menu to separate Alerts and Toasts, and properly links to Pagination examples
