### PR TITLE
Updated mimetypes

### DIFF
--- a/cmd/wasmbuild/file.go
+++ b/cmd/wasmbuild/file.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -98,8 +99,14 @@ func (f *File) URL() string {
 
 func (f *File) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Set content type by extension first, then detect
+		contentType := mime.TypeByExtension(filepath.Ext(f.Path))
+		if contentType == "" {
+			contentType = http.DetectContentType(f.Data)
+		}
+
 		// Set the Content-Type and Content-Length headers
-		w.Header().Set("Content-Type", http.DetectContentType(f.Data))
+		w.Header().Set("Content-Type", contentType)
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(f.Data)))
 
 		// Set no-cache headers


### PR DESCRIPTION
This pull request improves how the content type is determined and set in the HTTP handler for serving files in `cmd/wasmbuild/file.go`. The main change is to use the file extension to determine the content type before falling back to content detection, which results in more accurate and standard-compliant responses.

**HTTP handler improvements:**

* The handler now uses `mime.TypeByExtension` with the file's extension to determine the `Content-Type` header. If the extension doesn't provide a type, it falls back to `http.DetectContentType`, ensuring the most accurate content type is set for served files.
* Added an import for the `mime` package to support content type detection by file extension.