### PR TITLE
Upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Go parameters
 GO=$(shell which go)
 BUILDDIR=build
+NPM_CARBON_DIST_DIR ?= npm/carbon
+NPM_CARBON_BUNDLE := $(abspath $(NPM_CARBON_DIST_DIR))/bundle.js
 WASM=$(wildcard wasm/*)
 GOROOT=$(shell go env GOROOT)
 GOCC ?= go
@@ -14,7 +16,7 @@ LD_FLAGS = -X $(BUILD_MODULE)/pkg/version.GitSource=${BUILD_MODULE} -X $(BUILD_M
 all: wasmbuild npm generate $(WASM)
 
 # Generate icon names from the npm bundle.
-wasm/carbon-app/content/icon_names.go: npm/carbon/bundle.js
+wasm/carbon-app/content/icon_names.go: $(NPM_CARBON_BUNDLE)
 	@echo 'Generating icon names'
 	@cd wasm/carbon-app/content && $(GO) generate
 
@@ -28,11 +30,11 @@ $(WASM): wasmbuild generate
 	@$(BUILDDIR)/wasmbuild build --go=${GOCC} --go-flags='-ldflags "$(LD_FLAGS)"' -o ${BUILDDIR}/$(shell basename $@).wasm ./$@
 
 .PHONY: npm
-npm: npm/carbon/bundle.js
+npm: $(NPM_CARBON_BUNDLE)
 
-npm/carbon/bundle.js: npm/carbon/index.js npm/carbon/package.json
+$(NPM_CARBON_BUNDLE): npm/carbon/index.js npm/carbon/package.json npm/carbon/gen-icons.mjs
 	@echo 'Building npm/carbon bundle'
-	@cd npm/carbon && npm install && npm run build
+	@cd npm/carbon && npm install && CARBON_DIST_DIR='$(abspath $(NPM_CARBON_DIST_DIR))' npm run build
 
 .PHONY: wasmbuild
 wasmbuild: mkdir
@@ -65,6 +67,14 @@ tidy:
 .PHONY: clean
 clean: tidy
 	@rm -fr $(BUILDDIR)
-	@rm -f npm/carbon/bundle.js
+	@if [ '$(abspath $(NPM_CARBON_DIST_DIR))' = '$(abspath npm/carbon)' ]; then \
+		rm -f npm/carbon/bundle.js; \
+		rm -f npm/carbon/assets/themes.css; \
+		rm -f npm/carbon/assets/grid.css; \
+		rm -fr npm/carbon/assets/icons; \
+	else \
+		rm -fr '$(abspath $(NPM_CARBON_DIST_DIR))'; \
+	fi
+	@rm -f npm/carbon/icons-generated.js
 	@rm -f wasm/carbon-app/content/icon_names.go
 	$(GO) clean

--- a/npm/carbon/build.mjs
+++ b/npm/carbon/build.mjs
@@ -1,0 +1,46 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { build } from 'esbuild';
+import { fileURLToPath } from 'url';
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(process.env.CARBON_DIST_DIR || rootDir);
+const sourceAssetsDir = resolve(rootDir, 'assets');
+const distAssetsDir = resolve(distDir, 'assets');
+const sourceStylesPath = resolve(rootDir, 'node_modules', '@carbon', 'styles', 'css', 'styles.css');
+const sourceIconsDir = resolve(rootDir, 'node_modules', '@carbon', 'icons', 'svg');
+
+await import('./gen-icons.mjs');
+
+mkdirSync(distDir, { recursive: true });
+
+await build({
+    entryPoints: [resolve(rootDir, 'index.js')],
+    bundle: true,
+    format: 'esm',
+    minify: true,
+    outfile: resolve(distDir, 'bundle.js'),
+});
+
+if (distDir !== rootDir) {
+    rmSync(distAssetsDir, { recursive: true, force: true });
+    cpSync(sourceAssetsDir, distAssetsDir, { recursive: true });
+}
+
+mkdirSync(distAssetsDir, { recursive: true });
+rmSync(resolve(distAssetsDir, 'icons'), { recursive: true, force: true });
+cpSync(sourceIconsDir, resolve(distAssetsDir, 'icons'), { recursive: true });
+
+const stylesLines = readFileSync(sourceStylesPath, 'utf8').split('\n');
+writeFileSync(
+    resolve(distAssetsDir, 'themes.css'),
+    '/* Carbon theme tokens (generated) */\n' + stylesLines.slice(2786, 4107).join('\n')
+);
+writeFileSync(
+    resolve(distAssetsDir, 'grid.css'),
+    '/* Carbon CSS grid (generated) */\n' + stylesLines.slice(1063, 1862).join('\n')
+);
+
+if (!existsSync(resolve(distDir, 'bundle.js'))) {
+    throw new Error('bundle.js was not created');
+}

--- a/npm/carbon/package-lock.json
+++ b/npm/carbon/package-lock.json
@@ -6,17 +6,17 @@
     "": {
       "name": "carbon-bundle",
       "dependencies": {
-        "@carbon/pictograms": "^12.0.0",
-        "@carbon/web-components": "^2.0.0"
+        "@carbon/pictograms": "^12.73.0",
+        "@carbon/web-components": "^2.52.0"
       },
       "devDependencies": {
         "esbuild": "^0.25.0"
       }
     },
     "node_modules/@carbon/colors": {
-      "version": "11.48.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.48.0.tgz",
-      "integrity": "sha512-fJfgGBlzKugSS32z9/yI+XrSgiZttrFPBcsqrfxMjWAIPCRke1l3nypfL0AenetVof95dE38KA09i08uK9Zl2Q==",
+      "version": "11.50.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.50.0.tgz",
+      "integrity": "sha512-wJrJvBWiQOoVD0jaKHflC7MFESvzERmL9PCbNK15mCKZRtCZNOP5XhwGRlSrP83DNBmG0kVhCjIt/kmtmXiJHQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@carbon/feature-flags": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-1.1.0.tgz",
-      "integrity": "sha512-C9RigNQgO2WAKHjiZqJoumx3nBqs7n4fQETylHvrDeuVylztCCi7PCbr/yfpiUBfCervAsnYisBXynfH7Gcqcw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-1.2.0.tgz",
+      "integrity": "sha512-TL5YOL3YfJy0lSjaAiHmf/7pn7XP+SOkqxEQa/BMsnox80P4M7Kf51O9ElHwsEGBpcemtHv99WSTxmK9Y/LHbQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -34,13 +34,13 @@
       }
     },
     "node_modules/@carbon/grid": {
-      "version": "11.51.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.51.0.tgz",
-      "integrity": "sha512-5x4ri8GCBjckxd7/QuJzWwdcoCdhukeOcZ3ASrYnMY8IYEo+7NzBjIIFA4M7B5jsT2zd29uIIZqcTHcPg+1L8w==",
+      "version": "11.53.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.53.0.tgz",
+      "integrity": "sha512-Swm2v62cTDi+FNPO5mXempbAiCJb/Esh+ZfIfDKbhCGzgxwqrBpZwoZxM1BE/vhKTvo7a++wDMTj/ycftTTJKQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/layout": "^11.49.0",
+        "@carbon/layout": "^11.51.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@carbon/icons": {
-      "version": "11.76.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.76.0.tgz",
-      "integrity": "sha512-e9XnUWPgxsyvgCL/ti/Ee2fItqRs/WrHkwy7GPqbEGdGZKSd9pBvO+jN7nxBT5TLdA50q26t5hR0U2taEyc5Kg==",
+      "version": "11.78.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.78.0.tgz",
+      "integrity": "sha512-EWqJbFSSpV0UTc8/9SiTzPcEcqmryKwospDyzC0+nFIrCtlZPFuma2jpdoiJ87TMCx/Bm1pD5lGqucxuMZkwnQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@carbon/layout": {
-      "version": "11.49.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.49.0.tgz",
-      "integrity": "sha512-eT/G2o7sF80r5r8NJSDuLTQmVMr1u7VjQEkANVeaLg366VF5q36tCKgbs6kzFgJPEZhifonajIp27cS+gfylvQ==",
+      "version": "11.51.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.51.0.tgz",
+      "integrity": "sha512-V+D6jOZMXlYMDdppHTMvmQB46CnAKwA8OjDt7EX9lNbRbaig/fLfqbtTWM4rgy7VjyOqsDOBMVzyffiiz5HPzQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@carbon/motion": {
-      "version": "11.42.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.42.0.tgz",
-      "integrity": "sha512-FYBBMnYanddsxGilGSM8/8u0HXLY1hpfbtgpdWCsjUXtxZLvBHYKPbStJWBkvmDuwfAxeweS1xEFCYNIYIzNGA==",
+      "version": "11.44.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.44.0.tgz",
+      "integrity": "sha512-yBKiJ83xqiFbofqfCFaFxOPpbFKkm0hnn4yymLjFHPsNsBseRqg5qZMg7ZeW6JgecAXYNvzKpKxu4MJEGoMoUg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@carbon/pictograms": {
-      "version": "12.71.0",
-      "resolved": "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-12.71.0.tgz",
-      "integrity": "sha512-0kKUl+OICY9Jcs7izibsrQea0IHzI0e/qWOx9NYZF/d43x4B/FicBNlqHbOPXGe7Xc8AlDBtBkwoRj3X3YA3Sg==",
+      "version": "12.73.0",
+      "resolved": "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-12.73.0.tgz",
+      "integrity": "sha512-/xB+TXQ5f58ujlrCvv6ja/5KRuePedf7rKjfB8gH9PR72BS+uiTbz8aeoujEi+Fzxgg/qy8DiS38xxTzff6QVg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -95,19 +95,19 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.102.0.tgz",
-      "integrity": "sha512-Xi2esQ66FFlb8GUIL+Dj5qy9j0df4y5RfS/zMoNfAB5xgjDwqA6dWIwjk8NDywLeUiLfhG8CwovDP4d4QF2OsQ==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.104.0.tgz",
+      "integrity": "sha512-/YPg1RW6oJNoRgPyClsmsUpXqzXVTLzSfxhZN8bJPE5/vTC79Xaujas0mNSBrve3Ukb1XstwiwHZynil7msKxg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.48.0",
-        "@carbon/feature-flags": "^1.1.0",
-        "@carbon/grid": "^11.51.0",
-        "@carbon/layout": "^11.49.0",
-        "@carbon/motion": "^11.42.0",
-        "@carbon/themes": "^11.69.0",
-        "@carbon/type": "^11.55.0",
+        "@carbon/colors": "^11.50.0",
+        "@carbon/feature-flags": "^1.2.0",
+        "@carbon/grid": "^11.53.0",
+        "@carbon/layout": "^11.51.0",
+        "@carbon/motion": "^11.44.0",
+        "@carbon/themes": "^11.71.0",
+        "@carbon/type": "^11.57.0",
         "@ibm/plex": "6.0.0-next.6",
         "@ibm/plex-mono": "1.1.0",
         "@ibm/plex-sans": "1.1.0",
@@ -129,41 +129,41 @@
       }
     },
     "node_modules/@carbon/themes": {
-      "version": "11.69.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.69.0.tgz",
-      "integrity": "sha512-4Fh0N5vNVKwKLN/Mpmq/H48sfh8yJufCyjHX81CiC3G5wkzJJH1RJVbabp9vJLs0F2OEJhqpn3uvSsUBvNyDDg==",
+      "version": "11.71.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.71.0.tgz",
+      "integrity": "sha512-Lu77BR6HUKIRBSBHPttKkREHJFH87WDEBvwmmzKb6ZoGAg6KwkZYpXfQHvFU56I0JdRvTrePEoQMIm3R+2hr+A==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.48.0",
-        "@carbon/layout": "^11.49.0",
-        "@carbon/type": "^11.55.0",
+        "@carbon/colors": "^11.50.0",
+        "@carbon/layout": "^11.51.0",
+        "@carbon/type": "^11.57.0",
         "@ibm/telemetry-js": "^1.5.0",
         "color": "^4.0.0"
       }
     },
     "node_modules/@carbon/type": {
-      "version": "11.55.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.55.0.tgz",
-      "integrity": "sha512-VKSJ+TV/J2hdFkCqRuBqUJhtNIOG3BJCOEHv0L+bfrFk82mksnx59hsBtJKpnsgsZ9er+1e8hkZPqqo8dHRHvg==",
+      "version": "11.57.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.57.0.tgz",
+      "integrity": "sha512-B4XZfh9/CHfbJNfpR8/MuDGqAYiH19EzJQV3Dn/d86bSfVsoliD8h7WMKgRDDc0LmQmjpN/oJgnR7YM/3v5GmQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/grid": "^11.51.0",
-        "@carbon/layout": "^11.49.0",
+        "@carbon/grid": "^11.53.0",
+        "@carbon/layout": "^11.51.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/web-components": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-2.50.0.tgz",
-      "integrity": "sha512-JrSTQb9QCgHIMO0c673qP7PW78uZsPsX6s03Hm9AO0SEqCqekoKjZ4MzwSVfcbwbZ9mWkJ8JPZGKOwoRl6mQhg==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-2.52.0.tgz",
+      "integrity": "sha512-5Rx+e5i4R541vVBDVlLx+EJCEX5zpRUkqmP2xlRosV9RxDnw79nX7rkSfM8xXy8yCeokC7hbb12dyBLfX2n5eA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@carbon/icon-helpers": "10.47.0",
-        "@carbon/icons": "^11.76.0",
-        "@carbon/styles": "^1.102.0",
+        "@carbon/icons": "^11.78.0",
+        "@carbon/styles": "^1.104.0",
         "@floating-ui/dom": "^1.6.3",
         "@ibm/telemetry-js": "^1.10.2",
         "@lit/context": "^1.1.3",
@@ -895,9 +895,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/simple-swizzle": {

--- a/npm/carbon/package.json
+++ b/npm/carbon/package.json
@@ -2,13 +2,16 @@
   "name": "carbon-bundle",
   "private": true,
   "dependencies": {
-    "@carbon/pictograms": "^12.0.0",
-    "@carbon/web-components": "^2.0.0"
+    "@carbon/pictograms": "^12.73.0",
+    "@carbon/web-components": "^2.52.0"
+  },
+  "overrides": {
+    "lodash-es": "^4.18.1"
   },
   "devDependencies": {
     "esbuild": "^0.25.0"
   },
   "scripts": {
-    "build": "node gen-icons.mjs && esbuild index.js --bundle --format=esm --outfile=bundle.js --minify && cp -r node_modules/@carbon/icons/svg assets/icons && node -e \"const fs=require('fs'),l=fs.readFileSync('node_modules/@carbon/styles/css/styles.css','utf8').split('\\n');fs.writeFileSync('assets/themes.css','/* Carbon theme tokens (generated) */\\n'+l.slice(2786,4107).join('\\n'));fs.writeFileSync('assets/grid.css','/* Carbon CSS grid (generated) */\\n'+l.slice(1063,1862).join('\\n'));\""
+    "build": "node build.mjs"
   }
 }


### PR DESCRIPTION
This pull request refactors the build process for the `npm/carbon` bundle to be more flexible and robust, while also updating several dependencies to their latest versions. The most significant changes include introducing a new build script, improving asset handling, and updating the Makefile to support configurable output directories.

**Build Process Refactor and Asset Handling:**

- Added a new build script `build.mjs` that orchestrates the build process, including icon generation, JavaScript bundling with esbuild, copying assets, and extracting CSS slices for themes and grid. The script uses the `CARBON_DIST_DIR` environment variable to support outputting the bundle and assets to a configurable directory.
- Updated the Makefile to use the new `NPM_CARBON_DIST_DIR` and `NPM_CARBON_BUNDLE` variables, allowing the npm build output directory to be customized. The build, clean, and dependency rules now reference these variables and clean up all generated assets accordingly. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R5-R6) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L17-R19) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L31-R37) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L68-R78)
- Simplified the npm `build` script in `package.json` to delegate all build steps to `build.mjs`, ensuring consistency and maintainability.

**Dependency Updates:**

- Updated `@carbon/pictograms`, `@carbon/web-components`, and all related Carbon packages to their latest versions for improved compatibility and features. [[1]](diffhunk://#diff-897e255676d8ea08c24fee0c2a64ba7e9572d10bc873a74ccb7917f905e33aa4L9-R43) [[2]](diffhunk://#diff-897e255676d8ea08c24fee0c2a64ba7e9572d10bc873a74ccb7917f905e33aa4L58-R110) [[3]](diffhunk://#diff-897e255676d8ea08c24fee0c2a64ba7e9572d10bc873a74ccb7917f905e33aa4L132-R166)
- Added an `overrides` entry in `package.json` to ensure `lodash-es` is updated to version `4.18.1`, addressing potential issues with older versions. [[1]](diffhunk://#diff-ea538dbd0e805cfabdbf0ebdc4d2f3c26c95b501cf231d38e3c82932091225e3L5-R15) [[2]](diffhunk://#diff-897e255676d8ea08c24fee0c2a64ba7e9572d10bc873a74ccb7917f905e33aa4L898-R900)

These changes modernize the build process, make the output location flexible, and ensure dependencies are up to date for better reliability and maintainability.